### PR TITLE
added zip combinator & updated dependencies

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
 
-sbt.version=0.13.0
+sbt.version=0.13.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,17 @@
-addSbtPlugin("org.scala-lang.modules.scalajs" % "scalajs-sbt-plugin" % "0.4.0")
+addSbtPlugin("org.scala-lang.modules.scalajs" % "scalajs-sbt-plugin" % "0.4.1")
 
 resolvers += Resolver.sonatypeRepo("releases")
 
 resolvers += Resolver.sonatypeRepo("snapshots")
 
+resolvers +=  Resolver.url("scala-js-releases",
+  url("http://dl.bintray.com/content/scala-js/scala-js-releases"))(
+    Resolver.ivyStylePatterns)
+
 addSbtPlugin("com.lihaoyi" % "utest-js-plugin" % "0.1.2")
 
+//generates IDEA files
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")
+
+//dependency graph generation
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.4")

--- a/shared/test/scala/rx/AdvancedTests.scala
+++ b/shared/test/scala/rx/AdvancedTests.scala
@@ -226,6 +226,23 @@ object AdvancedTests extends TestSuite{
         assert(c() == 1347)
       }
     }
+
+    "zipper" - {
+      val a = Var(1)
+      val b = a.zip
+      val c = a.zip{case (a,b)=>s"$a => $b"}
+      a() = 2
+      assert(b() == (1,2))
+      assert(c() == "1 => 2")
+      a() = 3
+      assert(b() == (2,3))
+      assert(c() == "2 => 3")
+      a() = 4
+      assert(b() == (3,4))
+      assert(c() == "3 => 4")
+    }
+
+
     "kill" - {
       "killObs" - {
         val a = Var(1)


### PR DESCRIPTION
I added zip function that allows to map (oldvalue,newvalue) to another types (I think it is extremely useful in cases where we have to analyze the way how the value changed in comparison to old one), here are the tests:

```
"zipper" - {
  val a = Var(1)
  val b = a.zip
  val c = a.zip{case (a,b)=>s"$a => $b"}
  a() = 2
  assert(b() == (1,2))
  assert(c() == "1 => 2")
  a() = 3
  assert(b() == (2,3))
  assert(c() == "2 => 3")
  a() = 4
  assert(b() == (3,4))
  assert(c() == "3 => 4")
}
```
