### PR TITLE
Fix downstreams of Compose/Zoomed/Isomorphic Var

### DIFF
--- a/scalarx/shared/src/main/scala/rx/Rx.scala
+++ b/scalarx/shared/src/main/scala/rx/Rx.scala
@@ -19,8 +19,8 @@ trait Rx[+T] {
     */
   def now: T
 
-  private[rx] val downStream = mutable.Set.empty[Rx.Dynamic[_]]
-  private[rx] val observers = mutable.Set.empty[Obs]
+  private[rx] def downStream: mutable.Set[Rx.Dynamic[_]]
+  private[rx] def observers: mutable.Set[Obs]
 
   private[rx] def clearDownstream(): Unit = downStream.clear()
 
@@ -148,6 +148,9 @@ object Rx {
     * memory leaks from un-used [[Rx]]s hanging around.
     */
   class Dynamic[+T](func: (Ctx.Owner, Ctx.Data) => T, owner: Option[Ctx.Owner])(implicit name: sourcecode.Name) extends Rx[T] { self =>
+
+    private[rx] val downStream = mutable.Set.empty[Rx.Dynamic[_]]
+    private[rx] val observers = mutable.Set.empty[Obs]
 
     private[rx] var cached: Try[T @uncheckedVariance] = _
 

--- a/scalarx/shared/src/main/scala/rx/Var.scala
+++ b/scalarx/shared/src/main/scala/rx/Var.scala
@@ -94,14 +94,23 @@ object Var {
     override private[rx] val downStream = rx.downStream
     override private[rx] val observers = rx.observers
 
-
     // Proxy Var
     private[rx] var value = now
+
+    override private[rx] def addDownstream(ctx: Ctx.Data): Unit = rx.addDownstream(ctx)
+    override private[rx] def clearDownstream(): Unit = rx.clearDownstream()
+    override private[rx] def depth = rx.depth
+
+    override def kill() = {
+      rx.kill()
+      base.kill()
+    }
 
     def update(newValue: T): Unit = {
       // We do a regular update of the base-var, since we do not know if
       // rx.now will be newValue
       base.update(newValue)
+      value = rx.now
     }
   }
 

--- a/scalarx/shared/src/main/scala/rx/opmacros/Operators.scala
+++ b/scalarx/shared/src/main/scala/rx/opmacros/Operators.scala
@@ -209,7 +209,8 @@ object MapReadMacro {
     val tree = q"""
       val $baseValue = ${c.prefix}.base
       val $functionValue = ($param, $newOwnerCtx: $rxPkg.Ctx.Owner, $newDataCtx: $rxPkg.Ctx.Data) => $injected2
-      new $rxPkg.Var.Composed[$tType]($baseValue, $rxPkg.Rx.build { (owner,data) => $functionValue($baseValue, owner, data) })
+      val rx = $rxPkg.Rx.build { (owner,data) => $functionValue($baseValue, owner, data) }
+      new $rxPkg.Var.Composed[$tType]($baseValue, rx)
     """
 
     resetExpr[Var[T]](c)(tree)

--- a/scalarx/shared/src/test/scala/rx/BidirectionalVarOperators.scala
+++ b/scalarx/shared/src/test/scala/rx/BidirectionalVarOperators.scala
@@ -289,6 +289,62 @@ object TransformedVarTests extends TestSuite {
       assert(ia == 2)
       assert(ib == 2)
     }
+
+    "multiple dependencies with Composed" - {
+      import Ctx.Owner.Unsafe._
+      for( _ <- 0 to 100) { // catch nondeterminism
+        val base = Var(0)
+        val num = new Var.Composed(base, Rx { base() + 1 })
+        val combined = Rx {
+          base()
+          num()
+        }
+
+        assert(base.now == 0)
+        assert(num.now == 1)
+        assert(combined.now == 1)
+
+        num() = 1
+
+        assert(base.now == 1)
+        assert(num.now == 2)
+        assert(combined.now == 2)
+
+        base() = 1
+
+        assert(base.now == 1)
+        assert(num.now == 2)
+        assert(combined.now == 2)
+      }
+    }
+
+    "multiple dependencies with mapRead" - {
+      import Ctx.Owner.Unsafe._
+      for( _ <- 0 to 100) { // catch nondeterminism
+        val base = Var(0)
+        val num = base.mapRead { num => num() + 1 }
+        val combined = Rx {
+          base()
+          num()
+        }
+
+        assert(base.now == 0)
+        assert(num.now == 1)
+        assert(combined.now == 1)
+
+        num() = 1
+
+        assert(base.now == 1)
+        assert(num.now == 2)
+        assert(combined.now == 2)
+
+        base() = 1
+
+        assert(base.now == 1)
+        assert(num.now == 2)
+        assert(combined.now == 2)
+      }
+    }
   }
 }
 


### PR DESCRIPTION
This is just a test for `mapRead`. A variable is mapped and then both the base variable and the mapped variable are combined into an rx, which leads to inconsistent results.

I tried to debug, but could not find a reason for this behaviour.