### PR TITLE
add Rx.create for interfacing with callbacks

### DIFF
--- a/scalarx/shared/src/main/scala/rx/Rx.scala
+++ b/scalarx/shared/src/main/scala/rx/Rx.scala
@@ -101,6 +101,12 @@ object Rx {
     */
   def apply[T](func: => T)(implicit ownerCtx: rx.Ctx.Owner, name: sourcecode.Name): Rx.Dynamic[T] = macro Factories.rxApplyMacro[T]
 
+  def create[T](seed: T)(f: Var[T] => Unit): Rx[T] = {
+    val v = Var[T](seed)
+    f(v)
+    v
+  }
+
   private[rx] def unsafe[T](func: => T)(implicit name: sourcecode.Name): Rx[T] = macro Factories.buildUnsafe[T]
 
   /**

--- a/scalarx/shared/src/test/scala/rx/BasicTests.scala
+++ b/scalarx/shared/src/test/scala/rx/BasicTests.scala
@@ -41,6 +41,19 @@ object BasicTests extends TestSuite{
           b() = Some(2)
           assert (c.now == Some(3))
         }
+        "rxcreate"-{
+          val trigger = Var(5)
+          val a = Rx.create[Int](0) { write =>
+            trigger.triggerLater {
+              write() = trigger.now
+            }
+          }
+
+          assert(a.now == 0)
+
+          trigger() = 7
+          assert(a.now == 7)
+        }
       }
       "languageFeatures" - {
         "patternMatching" - {


### PR DESCRIPTION
This makes it easier creating variables from, e.g., callbacks without storing an intermediate `Var` in a variable.