### PR TITLE
add overload for trigger and triggerLater with argument

### DIFF
--- a/scalarx/shared/src/main/scala/rx/Rx.scala
+++ b/scalarx/shared/src/main/scala/rx/Rx.scala
@@ -87,6 +87,10 @@ trait Rx[+T] {
     o
   }
 
+  def trigger(f: T => Unit)(implicit ownerCtx: Ctx.Owner): Obs = trigger(f(now))
+
+  def triggerLater(f: T => Unit)(implicit ownerCtx: Ctx.Owner): Obs = triggerLater(f(now))
+
   def toTry: Try[T]
 }
 

--- a/scalarx/shared/src/test/scala/rx/BasicTests.scala
+++ b/scalarx/shared/src/test/scala/rx/BasicTests.scala
@@ -84,6 +84,16 @@ object BasicTests extends TestSuite{
         a() = 4
         assert(count == 5)
       }
+      "helloWorld2" - {
+        val a = Var(1)
+        var count = 0
+        val o = a.trigger{ a =>
+          count = a + 1
+        }
+        assert(count == 2)
+        a() = 4
+        assert(count == 5)
+      }
       "skipInitial" - {
         val a = Var(1)
         var count = 0
@@ -97,6 +107,18 @@ object BasicTests extends TestSuite{
         assert(count == 1)
         a() = 3
         assert(count == 2)
+      }
+      "skipInitial2" - {
+        val a = Var(1)
+        var count = 0
+        val o = a.triggerLater{ a =>
+          count = a + 1
+        }
+        assert(count == 0)
+        a() = 2
+        assert(count == 3)
+        a() = 3
+        assert(count == 4)
       }
 
       "simpleExample" - {


### PR DESCRIPTION
I always thought that triggerLater is not working correctly, since I was using it like this:

```scala
val a = Var(5)
a.triggerLater { (x: Int) => println(x) }
```

where function `Int => Unit` is happily converted into `=> Unit`, which compiles but does not make any sense (though `-Ywarn-value-discard` can help here).

Therefore, this PR adds overloaded version which take the current value as argument of the function.