### PR TITLE
improve Var.set test

### DIFF
--- a/scalarx/shared/src/test/scala/rx/AdvancedTests.scala
+++ b/scalarx/shared/src/test/scala/rx/AdvancedTests.scala
@@ -166,12 +166,16 @@ object AdvancedTests extends TestSuite{
           i += 1
         }
         assert(i == 1)
+        assert(d.now == 3)
         a() = 2
         assert(i == 2)
+        assert(d.now == 4)
         b() = 2
         assert(i == 3)
+        assert(d.now == 5)
         c() = 2
         assert(i == 4)
+        assert(d.now == 6)
 
         Var.set(
           a -> 3,
@@ -180,6 +184,7 @@ object AdvancedTests extends TestSuite{
         )
 
         assert(i == 5)
+        assert(d.now == 9)
 
         Var.set(
           Seq(
@@ -190,6 +195,7 @@ object AdvancedTests extends TestSuite{
         )
 
         assert(i == 6)
+        assert(d.now == 15)
       }
       "webPage" - {
         import Ctx.Owner.Unsafe._


### PR DESCRIPTION
While hunting a bug in an application, I looked how Var.set works and incidentally added some asserts to the `multiset` test.