### PR TITLE
cleanup observers in owner when killing Obs

### DIFF
--- a/scalarx/shared/src/main/scala/rx/Obs.scala
+++ b/scalarx/shared/src/main/scala/rx/Obs.scala
@@ -4,7 +4,7 @@ package rx
   * Wraps a simple callback, created by `trigger`, that fires when that
   * [[Rx]] changes.
   */
-class Obs(val thunk: () => Unit, upstream: Rx[_]) {
+class Obs(val thunk: () => Unit, upstream: Rx[_], owner: Option[Ctx.Owner]) {
 
   var dead = false
 
@@ -12,6 +12,7 @@ class Obs(val thunk: () => Unit, upstream: Rx[_]) {
     * Stop this observer from triggering and allow it to be garbage-collected
     */
   def kill(): Unit = {
+    owner.foreach(_.contextualRx.ownedObservers.remove(this))
     upstream.observers.remove(this)
     dead = true
   }

--- a/scalarx/shared/src/main/scala/rx/Rx.scala
+++ b/scalarx/shared/src/main/scala/rx/Rx.scala
@@ -79,10 +79,11 @@ trait Rx[+T] {
     * kill it later.
     */
   def triggerLater(thunk: => Unit)(implicit ownerCtx: rx.Ctx.Owner): Obs = {
-    val o = new Obs(() => thunk, this)
-    if (ownerCtx != Ctx.Owner.Unsafe) {
+    val o = if (ownerCtx != Ctx.Owner.Unsafe) {
+      val o = new Obs(() => thunk, this, Some(ownerCtx))
       ownerCtx.contextualRx.ownedObservers.add(o)
-    }
+      o
+    } else new Obs(() => thunk, this, None)
     observers.add(o)
     o
   }


### PR DESCRIPTION
If you have subscriptions with a `Owner.Compile`, you can never cleanup subscriptions yourself. For example:

```
Rx {
  ...
  val cancelable = someRx.foreach { println(_) }
}
```

Here, the owner of `foreach` will be injected in the Rx macro and therefore depend on all downstreams of this Rx block. So the previous owner will be killed whenever this Rx triggers. But let's say, I want to cancel the `cancelable` within the lifetime of the current owner. This is currently not possible because the cancelable is stored in the Owner as well and would therefore leak.

This PR removes the cancelable from the Owner when killing it. This will ensure it is really killed when done intentionally.