### PR TITLE
Add .metals and .bloop to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 target/
 .idea/
+
+.metals/
+.bloop/


### PR DESCRIPTION
Usually I'm in favor of everybody putting this into their local `.gitignore`. But I rarely see anybody doing this. I'm adding it to this repo, since `.idea` is also already in there.